### PR TITLE
Send transaction ids when check typing status request is received

### DIFF
--- a/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
@@ -317,7 +317,7 @@ BlueBubblesHelper *plugin;
     }];
 }
 
-+(BOOL) isTyping: (NSString *)guid transaction:(NSString *) transaction {
++(BOOL) isTyping: (NSString *)guid{
     IMChat *chat = [BlueBubblesHelper getChat:guid];
     return chat.lastIncomingMessage.isTypingMessage;
 }

--- a/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
@@ -327,7 +327,7 @@ BlueBubblesHelper *plugin;
     // Send out the correct response over the tcp socket
     if(chat.lastIncomingMessage.isTypingMessage == YES) {
         if (transaction != nil) {
-            [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"event": @"started-typing", @"guid": guid}];
+            [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"data": @"started-typing", @"guid": guid}];
         }else{
             [[NetworkController sharedInstance] sendMessage: @{@"event": @"started-typing", @"guid": guid}];
         }
@@ -335,7 +335,7 @@ BlueBubblesHelper *plugin;
         DLog(@"BLUEBUBBLESHELPER: %@ started typing", guid);
     } else {
         if (transaction != nil) {
-            [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"event": @"stopped-typing", @"guid": guid}];
+            [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"data": @"stopped-typing", @"guid": guid}];
         }else{
             [[NetworkController sharedInstance] sendMessage: @{@"event": @"stopped-typing", @"guid": guid}];
         }


### PR DESCRIPTION
Have not tested proof of concept. 
Development version of bb server requires a transaction id when checking typing status as a part of socket.on( 'update-typing-status' ) as part of commit https://github.com/BlueBubblesApp/bluebubbles-server/blob/6ddc934270440c310c793b480835f33028df5327/src/main/server/services/helperProcess/index.ts#L276-L277