### PR TITLE
fix: changed lastMessage to lastFinishedMessage

### DIFF
--- a/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
@@ -385,7 +385,7 @@ BlueBubblesHelper *plugin;
         messageToSend = [messageToSend initWithSender:(nil) time:(nil) text:(message) messageSubject:(subject) fileTransferGUIDs:(nil) flags:(100005) error:(nil) guid:(nil) subject:(nil) balloonBundleID:(nil) payloadData:(nil) expressiveSendStyleID:(effectId)];
         [chat sendMessage:(messageToSend)];
         if (transaction != nil) {
-            [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"identifier": [[chat lastMessage] guid]}];
+            [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"identifier": [[chat lastFinishedMessage] guid]}];
         }
     };
     


### PR DESCRIPTION
Fixes BlueBubblesApp/bluebubbles-app#1940

The problem relates to the typing status counting as a message from another individual. When a message is sent while the other user is typing, `lastMessage` returns the typing indicator, whereas `lastFinishedMessage` returns the proper message that was sent.

This has been tested on High Sierra locally but has not been tested by others or on other MacOS versions.