### PR TITLE
Update logging for better console debugging

### DIFF
--- a/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
@@ -64,14 +64,14 @@ NSMutableArray* vettedAliases;
         if (strLen > stepLog) {
         for (int i=1; i <= countInt; i++) {
             NSString *character = [logString substringWithRange:NSMakeRange((i*stepLog)-stepLog, stepLog)];
-            NSLog(@"BLUEBUBBLESHELPER: %@", character);
+            DLog("BLUEBUBBLESHELPER: %{public}@", character);
 
         }
         NSString *character = [logString substringWithRange:NSMakeRange((countInt*stepLog), strLen-(countInt*stepLog))];
-        NSLog(@"BLUEBUBBLESHELPER: %@", character);
+            DLog("BLUEBUBBLESHELPER: %{public}@", character);
         } else {
 
-        NSLog(@"BLUEBUBBLESHELPER: %@", logString);
+            DLog("BLUEBUBBLESHELPER: %{public}@", logString);
         }
 
 }
@@ -84,9 +84,9 @@ NSMutableArray* vettedAliases;
     // Get OS version for debugging purposes
     NSUInteger major = [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion;
     NSUInteger minor = [[NSProcessInfo processInfo] operatingSystemVersion].minorVersion;
-    DLog(@"BLUEBUBBLESHELPER: %@ loaded into %@ on macOS %ld.%ld", [self class], [[NSBundle mainBundle] bundleIdentifier], (long)major, (long)minor);
+    DLog("BLUEBUBBLESHELPER: %{public}@ loaded into %{public}@ on macOS %ld.%ld", [self class], [[NSBundle mainBundle] bundleIdentifier], (long)major, (long)minor);
 
-    DLog(@"BLUEBUBBLESHELPER: Initializing Connection in 5 seconds");
+    DLog("BLUEBUBBLESHELPER: Initializing Connection in 5 seconds");
 
     // I delay here for 5 seconds because there is a strange bug where
     // the plugin will spam think that a user starts and stops typing.
@@ -134,7 +134,7 @@ NSMutableArray* vettedAliases;
     NSMutableSet *difference = [setUpdated mutableCopy];
     [difference minusSet:setCurrent];
     NSArray *finalAliases = [difference valueForKey:@"dictionary"];
-    DLog(@"BLUEBUBBLESHELPER: Aliases Changed %@", finalAliases);
+    DLog("BLUEBUBBLESHELPER: Aliases Changed %{public}@", finalAliases);
     [[NetworkController sharedInstance] sendMessage: @{@"event": @"aliases-updated", @"aliases": finalAliases}];
 }
 
@@ -146,7 +146,7 @@ NSMutableArray* vettedAliases;
     if(range.location != NSNotFound){
      message = [message substringWithRange:NSMakeRange(0, range.location + 1)];
     }
-    DLog(@"BLUEBUBBLESHELPER: Received raw json: %@", message);
+    DLog("BLUEBUBBLESHELPER: Received raw json: %{public}@", message);
     NSError *error;
     NSData *jsonData = [message dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *dictionary = [NSJSONSerialization JSONObjectWithData:jsonData options:kNilOptions error:&error];
@@ -161,7 +161,7 @@ NSMutableArray* vettedAliases;
         transaction = dictionary[@"transactionId"];
     }
 
-    DLog(@"BLUEBUBBLESHELPER: Message received: %@, %@", event, data);
+    DLog("BLUEBUBBLESHELPER: Message received: %{public}@, %{public}@", event, data);
     
     // If the server tells us to start typing
      if([event isEqualToString: @"start-typing"]) {
@@ -235,7 +235,7 @@ NSMutableArray* vettedAliases;
                 [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction}];
             }
         }
-        DLog(@"BLUEBUBBLESHELPER: Setting display name of chat %@ to %@", data[@"chatGuid"], data[@"newName"]);
+        DLog("BLUEBUBBLESHELPER: Setting display name of chat %{public}@ to %{public}@", data[@"chatGuid"], data[@"newName"]);
     // If the server tells us to add a participant
     } else if ([event isEqualToString:@"add-participant"]) {
         IMChat *chat = [BlueBubblesHelper getChat: data[@"chatGuid"] :transaction];
@@ -265,12 +265,12 @@ NSMutableArray* vettedAliases;
             if (transaction != nil) {
                 [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction}];
             }
-            DLog(@"BLUEBUBBLESHELPER: Added participant to chat %@: %@", data[@"chatGuid"], data[@"address"]);
+            DLog("BLUEBUBBLESHELPER: Added participant to chat %{public}@: %{public}@", data[@"chatGuid"], data[@"address"]);
         } else {
             if (transaction != nil) {
                 [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"error": @"Failed to add address to chat!"}];
             }
-            DLog(@"BLUEBUBBLESHELPER: Couldn't add participant to chat %@: %@", data[@"chatGuid"], data[@"address"]);
+            DLog("BLUEBUBBLESHELPER: Couldn't add participant to chat %{public}@: %{public}@", data[@"chatGuid"], data[@"address"]);
         }
     // If the server tells us to remove a participant
     } else if ([event isEqualToString:@"remove-participant"]) {
@@ -296,12 +296,12 @@ NSMutableArray* vettedAliases;
             if (transaction != nil) {
                 [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction}];
             }
-            DLog(@"BLUEBUBBLESHELPER: Removed participant from chat %@: %@", data[@"chatGuid"], data[@"address"]);
+            DLog("BLUEBUBBLESHELPER: Removed participant from chat %{public}@: %{public}@", data[@"chatGuid"], data[@"address"]);
         } else {
             if (transaction != nil) {
                 [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"error": @"Failed to remove address from chat!"}];
             }
-            DLog(@"BLUEBUBBLESHELPER: Couldn't remove participant from chat %@: %@", data[@"chatGuid"], data[@"address"]);
+            DLog("BLUEBUBBLESHELPER: Couldn't remove participant from chat %{public}@: %{public}@", data[@"chatGuid"], data[@"address"]);
         }
     // If the server tells us to send a message or tapback
     } else if ([event isEqualToString:@"send-message"] || [event isEqualToString:@"send-reaction"]) {
@@ -488,7 +488,7 @@ NSMutableArray* vettedAliases;
 //            @try {
 //                SOAccountAlias* accountAlias = [aliasController aliasForName:alias];
 //
-//                DLog(@"BLUEBUBBLESHELPER: Modifying alias state: %@", accountAlias);
+//                DLog("BLUEBUBBLESHELPER: Modifying alias state: %{public}@", accountAlias);
 //                if (activate) {
 //                    [accountAlias activate];
 //                } else {
@@ -497,10 +497,10 @@ NSMutableArray* vettedAliases;
 //
 //                result = true;
 //            } @catch (NSException *exception) {
-//                DLog(@"BLUEBUBBLESHELPER: No alias found with name %@", alias);
+//                DLog("BLUEBUBBLESHELPER: No alias found with name %{public}@", alias);
 //            }
 //        } else {
-//            DLog(@"BLUEBUBBLESHELPER: Can't modify aliases, account not enabled");
+//            DLog("BLUEBUBBLESHELPER: Can't modify aliases, account not enabled");
 //        }
 //
 //        if (transaction != nil) {
@@ -512,7 +512,7 @@ NSMutableArray* vettedAliases;
 //        }
     // If the event is something that hasn't been implemented, we simply ignore it and put this log
     } else {
-        DLog(@"BLUEBUBBLESHELPER: Not implemented %@", event);
+        DLog("BLUEBUBBLESHELPER: Not implemented %{public}@", event);
     }
 
 }
@@ -539,7 +539,7 @@ NSMutableArray* vettedAliases;
 +(long long) parseReactionType:(NSString *)reactionType {
     NSString *lowerCaseType = [reactionType lowercaseString];
 
-    DLog(@"BLUEBUBBLESHELPER: %@", lowerCaseType);
+    DLog("BLUEBUBBLESHELPER: %{public}@", lowerCaseType);
 
     if([@"love" isEqualToString:(lowerCaseType)]) return 2000;
     if([@"like" isEqualToString:(lowerCaseType)]) return 2001;
@@ -576,7 +576,7 @@ NSMutableArray* vettedAliases;
 
 +(void) getMessageItem:(IMChat *)chat :(NSString *)actionMessageGuid completionBlock:(void (^)(IMMessage *message))block {
     [[IMChatHistoryController sharedInstance] loadMessageWithGUID:(actionMessageGuid) completionBlock:^(IMMessage *message) {
-        DLog(@"BLUEBUBBLESHELPER: Got message for guid %@", actionMessageGuid);
+        DLog("BLUEBUBBLESHELPER: Got message for guid %{public}@", actionMessageGuid);
         block(message);
     }];
 }
@@ -591,10 +591,10 @@ NSMutableArray* vettedAliases;
     // Send out the correct response over the tcp socket
     if(chat.lastIncomingMessage.isTypingMessage == YES) {
         [[NetworkController sharedInstance] sendMessage: @{@"event": @"started-typing", @"guid": guid}];
-        DLog(@"BLUEBUBBLESHELPER: %@ started typing", guid);
+        DLog("BLUEBUBBLESHELPER: %{public}@ started typing", guid);
     } else {
         [[NetworkController sharedInstance] sendMessage: @{@"event": @"stopped-typing", @"guid": guid}];
-        DLog(@"BLUEBUBBLESHELPER: %@ stopped typing", guid);
+        DLog("BLUEBUBBLESHELPER: %{public}@ stopped typing", guid);
     }
 }
 
@@ -608,13 +608,13 @@ NSMutableArray* vettedAliases;
 +(IMFileTransfer *) prepareFileTransferForAttachment:(NSURL *) originalPath filename:(NSString *) filename {
     // Creates the initial guid for the file transfer (cannot use for sending)
     NSString *transferInitGuid = [[IMFileTransferCenter sharedInstance] guidForNewOutgoingTransferWithLocalURL:originalPath useLegacyGuid:YES];
-    DLog(@"BLUEBUBBLESHELPER: Transfer GUID: %@", transferInitGuid);
+    DLog("BLUEBUBBLESHELPER: Transfer GUID: %{public}@", transferInitGuid);
 
     // Creates the initial transfer object
     IMFileTransfer *newTransfer = [[IMFileTransferCenter sharedInstance] transferForGUID:transferInitGuid];
     // Get location of where attachments should be placed
     NSString *persistentPath = [[IMDPersistentAttachmentController sharedInstance] _persistentPathForTransfer:newTransfer filename:filename highQuality:TRUE chatGUID:nil storeAtExternalPath:TRUE];
-    DLog(@"BLUEBUBBLESHELPER: Requested persistent path: %@", persistentPath);
+    DLog("BLUEBUBBLESHELPER: Requested persistent path: %{public}@", persistentPath);
 
     if (persistentPath) {
         NSError *folder_creation_error;
@@ -625,7 +625,7 @@ NSMutableArray* vettedAliases;
         [[NSFileManager defaultManager] createDirectoryAtURL:[persistentURL URLByDeletingLastPathComponent] withIntermediateDirectories:TRUE attributes:nil error:&folder_creation_error];
         // Handle error and exit
         if (folder_creation_error) {
-            DLog(@"BLUEBUBBLESHELPER:  Failed to create folder: %@", folder_creation_error);
+            DLog("BLUEBUBBLESHELPER:  Failed to create folder: %{public}@", folder_creation_error);
             return nil;
         }
 
@@ -633,7 +633,7 @@ NSMutableArray* vettedAliases;
         [[NSFileManager defaultManager] copyItemAtURL:originalPath toURL:persistentURL error:&file_move_error];
         // Handle error and exit
         if (file_move_error) {
-            DLog(@"BLUEBUBBLESHELPER:  Failed to move file: %@", file_move_error);
+            DLog("BLUEBUBBLESHELPER:  Failed to move file: %{public}@", file_move_error);
             return nil;
         }
 
@@ -646,7 +646,7 @@ NSMutableArray* vettedAliases;
     // Register the transfer (The file must be in correct location before this)
     // *Warning* Can fail but gives only warning in console that failed
     [[IMFileTransferCenter sharedInstance] registerTransferWithDaemon:[newTransfer guid]];
-    DLog(@"BLUEBUBBLESHELPER: Transfer registered successfully!");
+    DLog("BLUEBUBBLESHELPER: Transfer registered successfully!");
     return newTransfer;
 }
 
@@ -654,7 +654,7 @@ NSMutableArray* vettedAliases;
 +(void) sendMessage: (NSDictionary *) data transfers: (NSArray *) transfers attributedString:(NSMutableAttributedString *) attributedString transaction:(NSString *) transaction {
     IMChat *chat = [BlueBubblesHelper getChat: data[@"chatGuid"] :transaction];
     if (chat == nil) {
-        DLog(@"BLUEBUBBLESHELPER: chat is null, aborting");
+        DLog("BLUEBUBBLESHELPER: chat is null, aborting");
         return;
     }
     
@@ -786,11 +786,15 @@ NSMutableArray* vettedAliases;
  @return True if the account enabled state is 4 or false if else or not signed in
  */
 +(BOOL) isAccountEnabled {
+//
+//    DLog("BLUEBUBBLESHELPER: Registration Controller Trying To Load");
 //    SOAccountRegistrationController *registrationController = [SOAccountRegistrationController registrationController];
+//
+//    DLog("BLUEBUBBLESHELPER: Registration Controller %{public}@", registrationController);
 //
 //    if (registrationController != NULL && [registrationController isSignedIn]) {
 //        long long enabledState = [registrationController enabledState];
-//        NSLog(@"BLUEBUBBLESHELPER: Account Enabled State %lld", enabledState);
+//        DLog( "BLUEBUBBLESHELPER: Account Enabled State %{public}lld", enabledState);
 //        return enabledState == 4;
 //    } else {
 //        return FALSE;
@@ -809,19 +813,19 @@ NSMutableArray* vettedAliases;
 //        SOAccountAliasController* aliasController = [[SOAccountRegistrationController registrationController] aliasController];
 //
 //        NSArray* activeAliases = [aliasController vettedAliases];
-//        NSLog(@"BLUEBUBBLESHELPER: Vetted Aliases %@", activeAliases);
+//        DLog("BLUEBUBBLESHELPER: Vetted Aliases %{public}@", activeAliases);
 //
 //        NSMutableArray* returnedAliases = [[NSMutableArray alloc] init];
 //        for (SOAccountAlias* alias in activeAliases) {
-//            [returnedAliases addObject:[[VettedAliasDictionary alloc] initWithDictionary:@{
+//            [returnedAliases addObject:@{
 //                @"name": [alias name],
 //                @"active": [NSNumber numberWithBool:[alias active]]
-//            }]];
+//            }];
 //        }
 //
 //        return returnedAliases;
 //    } else {
-//        DLog(@"BLUEBUBBLESHELPER: Can't get aliases - account not enabled");
+//        DLog("BLUEBUBBLESHELPER: Can't get aliases - account not enabled");
 //        return [[NSMutableArray alloc] initWithArray:@[]];
 //    }
     return [[NSMutableArray alloc] initWithArray:@[]];
@@ -847,7 +851,7 @@ ZKSwizzleInterface(BBH_IMMessageItem, IMMessageItem, NSObject)
 
         if([self isLatestMessage]) {
             [[NetworkController sharedInstance] sendMessage: @{@"event": @"stopped-typing", @"guid": guid}];
-            DLog(@"BLUEBUBBLESHELPER: %@ stopped typing", guid);
+            DLog("BLUEBUBBLESHELPER: %{public}@ stopped typing", guid);
         }
     }
     return ZKOrig(BOOL);
@@ -870,7 +874,7 @@ ZKSwizzleInterface(BBH_IMMessageItem, IMMessageItem, NSObject)
             if(guid != nil) {
                 if([BlueBubblesHelper isTyping:guid] == NO) {
                     [[NetworkController sharedInstance] sendMessage: @{@"event": @"stopped-typing", @"guid": guid}];
-                    DLog(@"BLUEBUBBLESHELPER: %@ stopped typing", guid);
+                    DLog("BLUEBUBBLESHELPER: %{public}@ stopped typing", guid);
                 }
             }
         }
@@ -930,30 +934,30 @@ ZKSwizzleInterface(BBH_IMMessageItem, IMMessageItem, NSObject)
 //ZKSwizzleInterface(WBWT_IMChat, IMChat, NSObject)
 //@implementation WBWT_IMChat
 //-(void)_setDisplayName:(id)arg1 {
-//    DLog(@"BLUEBUBBLESHELPER: %@", [arg1 className]);
+//    DLog("BLUEBUBBLESHELPER: %{public}@", [arg1 className]);
 //}
 //@end
 //
 //-(void)sendMessageAcknowledgment:(long long)arg1 forChatItem:(id)arg2 withAssociatedMessageInfo:(id)arg3 withGuid:(id)arg4 {
-//    DLog(@"BLUEBUBBLESHELPER: sending reaction 1");
+//    DLog("BLUEBUBBLESHELPER: sending reaction 1");
 //    return;
 //}
 //
 //-(void)sendMessageAcknowledgment:(long long)arg1 forChatItem:(id)arg2 withAssociatedMessageInfo:(id)arg3 {
-//    DLog(@"BLUEBUBBLESHELPER: sending reaction 2");
+//    DLog("BLUEBUBBLESHELPER: sending reaction 2");
 //    return;
 //}
 //
 //-(void)sendMessageAcknowledgment:(long long)arg1 forChatItem:(id)arg2 withMessageSummaryInfo:(id)arg3 withGuid:(id)arg4 {
-//    DLog(@"BLUEBUBBLESHELPER: sending reaction 3");
+//    DLog("BLUEBUBBLESHELPER: sending reaction 3");
 //    return;
 //}
 //
 //-(void)sendMessageAcknowledgment:(long long)arg1 forChatItem:(id)arg2 withMessageSummaryInfo:(id)arg3 {
-//    DLog(@"BLUEBUBBLESHELPER: sending reaction 4");
-//    DLog(@"BLUEBUBBLESHELPER: %lld", arg1);
-//    DLog(@"BLUEBUBBLESHELPER: %@", arg2);
-//    DLog(@"BLUEBUBBLESHELPER: %@", arg3);
+//    DLog("BLUEBUBBLESHELPER: sending reaction 4");
+//    DLog("BLUEBUBBLESHELPER: %lld", arg1);
+//    DLog("BLUEBUBBLESHELPER: %{public}@", arg2);
+//    DLog("BLUEBUBBLESHELPER: %{public}@", arg3);
 //
 //
 //    return;
@@ -971,7 +975,7 @@ ZKSwizzleInterface(BBH_IMMessageItem, IMMessageItem, NSObject)
 //     IMMessage[from=(null); msg-subject=(null); account:(null); flags=5; subject='(null)' text='(null)' messageID: 0 GUID:'79045C8B-1E6E-480B-8819-37E36C517578' sortID: 0 date:'627629508.210384' date-delivered:'0.000000' date-read:'0.000000' date-played:'0.000000' empty: NO finished: YES sent: NO read: NO delivered: NO audio: NO played: NO from-me: YES emote: NO dd-results: NO dd-scanned: NO error: (null) associatedMessageGUID: p:0/0C14634E-563D-408C-B9D4-805FEF7ADC7B associatedMessageType: 2001 balloonBundleID: (null) expressiveSendStyleID: (null) timeExpressiveSendStylePlayed: 0.000000 bizIntent:(null) locale:(null), ]
 //
 //     */
-//    DLog(@"BLUEBUBBLESHELPER: sendMessage %@", arg1);
+//    DLog("BLUEBUBBLESHELPER: sendMessage %{public}@", arg1);
 //    ZKOrig(void, arg1);
 //}
 //
@@ -1010,7 +1014,7 @@ ZKSwizzleInterface(BBH_IMMessageItem, IMMessageItem, NSObject)
 //
 //- (void)_updateTimeRead:(id)arg1 {
 //    ZKOrig(void, arg1);
-//    DLog(@"typeStatus : _updateTimeRead");
+//    DLog("typeStatus : _updateTimeRead");
 //}
 //
 //@end

--- a/MacOS-11+/BlueBubblesHelper/Logging.h
+++ b/MacOS-11+/BlueBubblesHelper/Logging.h
@@ -5,14 +5,21 @@
 //  Created by Samer Shihabi on 11/29/20.
 //  Copyright © 2020 BlueBubbleMessaging. All rights reserved.
 //
-
+#include <os/log.h>
 #ifndef Logging_h
 #define Logging_h
 
+
 #ifdef DEBUG
-#    define DLog(...) NSLog(__VA_ARGS__)
+#    define ELog(N, ...) os_log_with_type(os_log_create("com.bluebubbles.messaging", "DEBUG"),OS_LOG_TYPE_ERROR,N,##__VA_ARGS__)
+#else
+#    define ELog(...) /* */
+#endif
+#ifdef DEBUG
+#    define DLog(N, ...) os_log_with_type(os_log_create("com.bluebubbles.messaging", "DEBUG"),OS_LOG_TYPE_DEFAULT,N ,##__VA_ARGS__)
 #else
 #    define DLog(...) /* */
 #endif
+
 
 #endif /* Logging_h */

--- a/MacOS-11+/BlueBubblesHelper/NetworkController.m
+++ b/MacOS-11+/BlueBubblesHelper/NetworkController.m
@@ -46,13 +46,13 @@ static id sharedInstance = nil;
     // we'll subtract 501 to get an id starting at 0, incremented for each user
     // then we add this to the base port to get a unique port for the socket
     int port = CLAMP(45670 + getuid()-501, 45670, 65535);
-    DLog(@"BLUEBUBBLESHELPER: Connecting to socket on port %d", port);
+    DLog("BLUEBUBBLESHELPER: Connecting to socket on port %{public}d", port);
     // connect to socket
     asyncSocket = [[GCDAsyncSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_main_queue()];
     NSError *err = nil;
     if (![asyncSocket connectToHost:@"localhost" onPort:port error:&err]) {
         // If there was an error, it's likely something like "already connected" or "no delegate set"
-        DLog(@"BLUEBUBBLESHELPER: Error connecting to socket: %@", err);
+        DLog("BLUEBUBBLESHELPER: Error connecting to socket: %{public}@", err);
     }
     // initiate the 1st read request in anticipation
     [asyncSocket readDataWithTimeout:(-1) tag:(1)];
@@ -71,28 +71,28 @@ static id sharedInstance = nil;
     // add a newline to the message so back-to-back messages are split and sent correctly
     NSString *jsonMessage = [NSString stringWithFormat:(@"%@\r\n"), message];
     NSData* finalData = [jsonMessage dataUsingEncoding:NSUTF8StringEncoding];
-    DLog(@"BLUEBUBBLESHELPER: data: %@", data[@"event"]);
+    DLog("BLUEBUBBLESHELPER: data: %{public}@", data[@"event"]);
     [asyncSocket writeData:(finalData) withTimeout:(-1) tag:(1)];
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(UInt16)port {
-    DLog(@"BLUEBUBBLESHELPER: socket:%p didConnectToHost:%@ port:%hu", sock, host, port);
+    DLog("BLUEBUBBLESHELPER: socket:%{public}p didConnectToHost:%{public}@ port:%{public}hu", sock, host, port);
     NSDictionary *message = @{@"event": @"ping", @"message": @"Helper Connected!"};
     [self sendMessage:message];
 }
 
 - (void)socketDidSecure:(GCDAsyncSocket *)sock {
-    DLog(@"BLUEBUBBLESHELPER: socketDidSecure:%p", sock);
+    DLog("BLUEBUBBLESHELPER: socketDidSecure:%{public}p", sock);
 }
 
 // called when a message is sent to the server
 - (void)socket:(GCDAsyncSocket *)sock didWriteDataWithTag:(long)tag {
-    DLog(@"BLUEBUBBLESHELPER: socket:%p didWriteDataWithTag:%ld", sock, tag);
+    DLog("BLUEBUBBLESHELPER: socket:%p didWriteDataWithTag:%ld", sock, tag);
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
     NSString* str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    DLog(@"BLUEBUBBLESHELPER: event: %@ socket:%p didReadData:withTag:%ld", str, sock, tag);
+    DLog("BLUEBUBBLESHELPER: event: %{public}@ socket:%{public}p didReadData:withTag:%{public}ld", str, sock, tag);
     // initiate a new read request for the next data item
     [asyncSocket readDataWithTimeout:(-1) tag:(1)];
     // send the data to the handler
@@ -100,11 +100,11 @@ static id sharedInstance = nil;
 }
 
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err {
-    DLog(@"BLUEBUBBLESHELPER: Disconnected from server, attempting to reconnect in 5 seconds...");
+    DLog("BLUEBUBBLESHELPER: Disconnected from server, attempting to reconnect in 5 seconds...");
     double delayInSeconds = 5.0;
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-        DLog(@"BLUEBUBBLESHELPER: Attempting to reconnect");
+        DLog("BLUEBUBBLESHELPER: Attempting to reconnect");
         [self connect];
     });
 }


### PR DESCRIPTION
Logs now show in the devices tab in console
Searching for subsystem com.bluebubbles.messageing in console filters all helper messages now
Full log messages now print out to console
ELog added which shows a error highlight in console
 
More details:
By default I set everything to public (Possible sensitive information shows) which was the default functionality with the old Dlog but to use apple's automatic hiding of sensitive information (Making sharing logs with devs not take a ton of redacting) public can be removed. With this command
 `$ sudo log config --mode "level:debug" --subsystem com.bluebubbles.messaging
` 
it can be set to show private information without having to manually set everything to public more information here 
Learn more about how things are auto hidden and types:
https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code?language=objc#3665948
Learn more about how to unhide things from console using that command
https://developer.apple.com/documentation/os/logging/customizing_logging_behavior_while_debugging?language=objc
