### PR TITLE
Fix `scanMessage` Implementation

### DIFF
--- a/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
@@ -671,7 +671,7 @@ NSMutableArray* vettedAliases;
     } else if ([event isEqualToString:@"share-nickname"]) {
         IMChat *chat = [BlueBubblesHelper getChat:data[@"chatGuid"] :transaction];
 
-        if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
+        if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 11) {
             [[IMNicknameController sharedInstance] whitelistHandlesForNicknameSharing:[chat participants] forChat:chat];
         } else {
             [[IMNicknameController sharedInstance] allowHandlesForNicknameSharing:[chat participants] forChat:chat];

--- a/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
@@ -921,7 +921,7 @@ NSMutableArray* vettedAliases;
  */
 +(IMFileTransfer *) prepareFileTransferForAttachment:(NSURL *) originalPath filename:(NSString *) filename {
     // Creates the initial guid for the file transfer (cannot use for sending)
-    NSString *transferInitGuid = [[IMFileTransferCenter sharedInstance] guidForNewOutgoingTransferWithLocalURL:originalPath];
+    NSString *transferInitGuid = [[IMFileTransferCenter sharedInstance] guidForNewOutgoingTransferWithLocalURL:originalPath useLegacyGuid:YES];
     DLog("BLUEBUBBLESHELPER: Transfer GUID: %{public}@", transferInitGuid);
 
     // Creates the initial transfer object
@@ -996,7 +996,7 @@ NSMutableArray* vettedAliases;
         isAudioMessage = [data[@"isAudioMessage"] integerValue] == 1;
     }
     
-    BOOL ddScan = true;
+    BOOL ddScan = false;
     if (data[@"ddScan"] != [NSNull null]) {
         ddScan = [data[@"ddScan"] integerValue] == 1;
     }
@@ -1013,11 +1013,7 @@ NSMutableArray* vettedAliases;
             __strong typeof(messageToSend) strongMessage = messageToSend;
             __strong typeof(chat) strongChat = chat;
             
-            [[IMDDController sharedInstance]
-                scanMessage:strongMessage
-                     outgoing:YES
-                waitUntilDone:YES
-             completionBlock:^(NSInteger status, BOOL success, id result) {
+            [[IMDDController sharedInstance] scanMessage:strongMessage outgoing:TRUE waitUntilDone:TRUE completionBlock:^(NSInteger status, BOOL success, id result) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [strongChat sendMessage:(strongMessage)];
                     if (transaction != nil) {

--- a/Messages/MacOS-11+/BlueBubblesHelper/IMDDController.h
+++ b/Messages/MacOS-11+/BlueBubblesHelper/IMDDController.h
@@ -15,6 +15,7 @@
 
 @property (retain, nonatomic) NSObject<OS_dispatch_queue> *scannerQueue; // ivar: _scannerQueue
 
+@property (nonatomic, readonly) dispatch_queue_t queue;
 
 +(id)sharedInstance;
 -(BOOL)_scanAttributedStringWithMessage:(id)arg0 attributedString:(id)arg1 plainText:(id)arg2 ;
@@ -25,8 +26,8 @@
 -(void)scanMessage:(id)arg0 completionBlock:(id)arg1 ;
 -(void)scanMessage:(id)arg0 outgoing:(BOOL)arg1 waitUntilDone:(BOOL)arg2 completionBlock:(id)arg3 ;
 
+-(void)scanMessage:(id)arg0 outgoing:(BOOL)arg1 waitUntilDone:(BOOL)arg2 completionBlock:(id)arg3;
 
 @end
-
 
 #endif

--- a/Messages/MacOS-11+/BlueBubblesHelper/IMDDController.h
+++ b/Messages/MacOS-11+/BlueBubblesHelper/IMDDController.h
@@ -14,7 +14,6 @@
 @interface IMDDController : NSObject
 
 @property (retain, nonatomic) NSObject<OS_dispatch_queue> *scannerQueue; // ivar: _scannerQueue
-
 @property (nonatomic, readonly) dispatch_queue_t queue;
 
 +(id)sharedInstance;
@@ -26,8 +25,8 @@
 -(void)scanMessage:(id)arg0 completionBlock:(id)arg1 ;
 -(void)scanMessage:(id)arg0 outgoing:(BOOL)arg1 waitUntilDone:(BOOL)arg2 completionBlock:(id)arg3 ;
 
--(void)scanMessage:(id)arg0 outgoing:(BOOL)arg1 waitUntilDone:(BOOL)arg2 completionBlock:(id)arg3;
 
 @end
+
 
 #endif


### PR DESCRIPTION
The `IMDDController.sharedInstance.scanMessage` method, which is used to detect rich message content in text, is currently broken.

There are 3 problems:
 
1. The completionBlock signature has changed and now takes 3 parameters (not 2).
2. The scanMessage method now mutates the message you pass it directly, so you don't want to actually touch any of the completionBlock arguments like the code currently does.
3. The call to send the message needs to be dispatched to the main thread to avoid crashing when exiting the completionBlock.

Tested on 2 instances running:
[1] macOS 15.1.1
[2] macOS 15.2

Both instances serve high message volume (i.e. thousands of messages in/out across iMessage/SMS/RCS handles) and both have been working smoothly since yesterday.