### PR TITLE
fix: guard _newChatItems against IMMessageAcknowledgmentChatItem crash on macOS Tahoe

### DIFF
--- a/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
@@ -348,6 +348,8 @@ NSMutableArray* vettedAliases;
             // sometimes items is an array so we need to account for that
             if ([items isKindOfClass:[NSArray class]]) {
                 for (IMMessagePartChatItem *i in (NSArray *) items) {
+                    // Skip items that don't have an index selector (e.g. IMMessageAcknowledgmentChatItem on Tahoe)
+                    if (![i respondsToSelector:@selector(index)]) continue;
                     // IMAggregateAttachmentMessagePartChatItem is a photo gallery and has subparts
                     // Only available Monterey+, use reference to class loaded at runtime to avoid crashes on Big Sur
                     Class cls = NSClassFromString(@"IMAggregateAttachmentMessagePartChatItem");
@@ -606,8 +608,14 @@ NSMutableArray* vettedAliases;
             IMMessagePartChatItem *item;
             // sometimes items is an array so we need to account for that
             if ([items isKindOfClass:[NSArray class]]) {
-                item = [(NSArray*) items firstObject];
-            } else {
+                // Find first actual IMMessagePartChatItem, skipping acknowledgments etc.
+                for (id obj in (NSArray *)items) {
+                    if ([obj isKindOfClass:[IMMessagePartChatItem class]]) {
+                        item = obj;
+                        break;
+                    }
+                }
+            } else if ([items isKindOfClass:[IMMessagePartChatItem class]]) {
                 item = (IMMessagePartChatItem *)items;
             }
 
@@ -1044,6 +1052,8 @@ NSMutableArray* vettedAliases;
             // sometimes items is an array so we need to account for that
             if ([items isKindOfClass:[NSArray class]]) {
                 for (IMMessagePartChatItem *i in (NSArray *) items) {
+                    // Skip items that don't have an index selector (e.g. IMMessageAcknowledgmentChatItem on Tahoe)
+                    if (![i respondsToSelector:@selector(index)]) continue;
                     // IMAggregateAttachmentMessagePartChatItem is a photo gallery and has subparts
                     // Only available Monterey+, use reference to class loaded at runtime to avoid crashes on Big Sur
                     Class cls = NSClassFromString(@"IMAggregateAttachmentMessagePartChatItem");


### PR DESCRIPTION
## Summary

On macOS 26 (Tahoe), `_newChatItems` can return `IMMessageAcknowledgmentChatItem` objects mixed in with `IMMessagePartChatItem` objects. The code blindly iterates the array and calls `[item index]`, but `IMMessageAcknowledgmentChatItem` inherits from `IMChatItem` — which doesn't have an `-index` selector. This causes an unrecognized selector crash that kills the helper dylib.

**Changes:**
- Added `[i respondsToSelector:@selector(index)]` guard in `unsend-message` handler iteration
- Added same guard in `sendMessage` handler (reply threading + tapback path via `selectedMessageGuid`)
- Hardened `notify-anyways` handler to use `isKindOfClass:[IMMessagePartChatItem class]` filtering instead of blind `firstObject` cast

## Test plan

- [x] Built universal binary (x86_64 + arm64 + arm64e) on macOS 26.4
- [x] Helper injected and connected successfully (`helper_connected: true`)
- [x] Reply threading via `selectedMessageGuid` no longer crashes
- [x] Tapback sending no longer crashes

Fixes #776