### PR TITLE
Fix delete-message handler: call deleteIMMessageItems: instead of deleteChatItems:

### DIFF
--- a/Messages/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/Messages/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m
@@ -374,15 +374,18 @@ BlueBubblesHelper *plugin;
         if (chat != nil) {
             [BlueBubblesHelper getMessageItem:(chat) :(data[@"messageGuid"]) completionBlock:^(IMMessage *message) {
                 IMMessageItem *messageItem = (IMMessageItem *)message._imMessageItem;
-                NSObject *items = messageItem._newChatItems;
-                // sometimes items is an array so we need to account for that
-                if ([items isKindOfClass:[NSArray class]]) {
-                    [chat deleteChatItems:(items)];
-                } else {
-                    [chat deleteChatItems:(@[items])];
+                // Use deleteIMMessageItems: (whole-message delete) rather than
+                // deleteChatItems: (message-parts delete). The latter hits
+                // IMCore's "delete subset of chat items from message → update
+                // message" path which leaves the row in place; only
+                // deleteIMMessageItems: actually removes the message and
+                // writes to sync_deleted_messages so the delete propagates
+                // via iCloud.
+                if (messageItem != nil) {
+                    [chat deleteIMMessageItems:@[messageItem]];
                 }
             }];
-            
+
             if (transaction != nil) {
                 [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction}];
             }

--- a/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
@@ -445,13 +445,16 @@ NSMutableArray* vettedAliases;
         if (chat != nil) {
             [BlueBubblesHelper getMessageItem:(chat) :(data[@"messageGuid"]) completionBlock:^(IMMessage *message) {
                 IMMessageItem *messageItem = (IMMessageItem *)message._imMessageItem;
-                NSObject *items = messageItem._newChatItems;
-                IMMessagePartChatItem *item;
-                // sometimes items is an array so we need to account for that
-                if ([items isKindOfClass:[NSArray class]]) {
-                    [chat deleteChatItems:(items)];
-                } else {
-                    [chat deleteChatItems:(@[items])];
+                // Use deleteIMMessageItems: (whole-message delete) rather than
+                // deleteChatItems: (message-parts delete). The latter hits
+                // IMCore's "delete subset of chat items from message → update
+                // message" path which leaves the row in place; only
+                // deleteIMMessageItems: actually removes the message and
+                // writes to sync_deleted_messages so the delete propagates
+                // via iCloud. Observed on macOS 26 Tahoe; previously the
+                // API returned 200 but chat.db was unchanged.
+                if (messageItem != nil) {
+                    [chat deleteIMMessageItems:@[messageItem]];
                 }
             }];
 


### PR DESCRIPTION
## Summary

The `delete-message` action in `BlueBubblesHelper.m` calls `-[IMChat deleteChatItems:]` with an array of `IMMessagePartChatItem` (message parts — text ranges, attachment slots). This hits IMCore's **\"delete subset of chat items from message → update message\"** code path, which logs activity that looks like a delete is happening:

```
(IMCore) [ChatItems] Processing 1 chat items for deletion
(IMCore) [ChatItems] Request to delete subset of chatItems from message. Update message.
(IMCore) [ChatItems] DELETING PARTS index:range map: <private>
```

…but the message row stays in `chat_message_join`, no entry is written to `sync_deleted_messages`, and nothing propagates via iCloud. Meanwhile, the HTTP API returns `{\"status\":200,\"message\":\"Successfully deleted message!\"}` because the transaction ACK in the helper fires **outside** the `getMessageItem:completionBlock:` callback, so the server never sees the no-op.

The correct method for whole-message delete is `-[IMChat deleteIMMessageItems:]`, which takes an array of `IMMessageItem` and invokes IMCore's real delete path — row removal, `sync_deleted_messages` entry with a CloudKit `recordID`, and iCloud propagation to all signed-in devices.

Both methods are already declared in the existing `IMChat.h` headers for MacOS-10 and MacOS-11+, so no new imports are required.

## The fix

```diff
 } else if ([event isEqualToString:@\"delete-message\"]) {
     IMChat *chat = [BlueBubblesHelper getChat: data[@\"chatGuid\"] :transaction];
     if (chat != nil) {
         [BlueBubblesHelper getMessageItem:(chat) :(data[@\"messageGuid\"]) completionBlock:^(IMMessage *message) {
             IMMessageItem *messageItem = (IMMessageItem *)message._imMessageItem;
-            NSObject *items = messageItem._newChatItems;
-            IMMessagePartChatItem *item;
-            if ([items isKindOfClass:[NSArray class]]) {
-                [chat deleteChatItems:(items)];
-            } else {
-                [chat deleteChatItems:(@[items])];
+            if (messageItem != nil) {
+                [chat deleteIMMessageItems:@[messageItem]];
             }
         }];
         ...
     }
 }
```

Applied to both `Messages/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m` and `Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m` since both copies had identical incorrect code.

## Diagnostic notes

Caught with \`log stream --predicate 'process == \"Messages\"' --level debug\` on macOS 26.4 Tahoe while firing `DELETE /api/v1/chat/:guid/:messageGuid`. The IMCore logs above made it clear the call was going down the part-delete path; cross-referencing `IMChat.h` in this repo showed `deleteIMMessageItems:` sitting right next to `deleteChatItems:` at lines 376-377, confirming the correct method exists.

One subtlety that masks the bug: the helper sends the transaction ACK immediately after kicking off `getMessageItem:completionBlock:`, not from inside the completion block. So even if the IMCore call was silently throwing or hanging, the server would still see success. Worth being aware of when debugging other actions.

## Verification

Verified end-to-end on macOS 26.4 Tahoe (Messages.app 26.0, IMCore 800.0.0):

1. Rebuilt the MacOS-11+ helper dylib with this fix using `clang -dynamiclib` directly against the SDK's private frameworks (no Xcode required, just Command Line Tools).
2. Deployed to `/Applications/BlueBubbles.app/Contents/Resources/appResources/private-api/macos11/BlueBubblesHelper.dylib`.
3. Killed and relaunched BlueBubbles. Confirmed the new dylib was injected into Messages.app via `lsof -p <messages_pid> | grep BlueBubbles`.
4. Issued 95 delete requests across 1:1 and group chats via a custom script. For each:
   - `message` row was removed from the table on the issuing device
   - `sync_deleted_messages` had an entry with a valid CloudKit recordID
   - The delete propagated to the other signed-in Mac's `chat_recoverable_message_join` within seconds
5. Zero crashes. Zero verify failures. Zero divergence between devices.

## Not verified

- Behavior on older macOS versions (Big Sur, Monterey, Ventura, Sonoma, Sequoia). The `deleteIMMessageItems:` selector is present in this repo's class-dumped `IMChat.h` for both MacOS-10 and MacOS-11+, so it should be available, but I haven't tested outside Tahoe. A quick sanity check from a maintainer on an earlier macOS would be helpful before merging.
- The `send-multipart` edge case where `_newChatItems` might have been relevant. I replaced the `_newChatItems` access entirely, so if there's a scenario where the helper legitimately needs to delete a subset of parts (e.g., removing an attachment while keeping text), this fix is too aggressive. I couldn't find such a call site in the BlueBubbles server, but if one exists, the fix may need to gate on whether the caller wants whole-message or part-level delete.

Opening as a draft so maintainers can weigh in on macOS-version coverage before landing.