### PR TITLE
feat: set-nickname-info action for Share Name and Photo writes

### DIFF
--- a/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
+++ b/Messages/MacOS-11+/BlueBubblesHelper/BlueBubblesHelper.m
@@ -702,6 +702,66 @@ NSMutableArray* vettedAliases;
             };
             [[NetworkController sharedInstance] sendMessage:data];
         }
+    // If the server tells us to write the personal Share Name and Photo
+    } else if ([event isEqualToString:@"set-nickname-info"]) {
+        NSString *displayName = data[@"displayName"];
+        NSString *avatarPath = data[@"avatarPath"];
+        NSString *avatarBytes = data[@"avatarBytes"];
+
+        if (displayName == nil || (id)displayName == [NSNull null] || [displayName length] == 0) {
+            if (transaction != nil) {
+                [[NetworkController sharedInstance] sendMessage: @{@"transactionId": transaction, @"error": @"displayName is required"}];
+            }
+            return;
+        }
+
+        // Split displayName into first/last for IMNickname's initWithFirstName:lastName:avatar:
+        NSString *firstName = displayName;
+        NSString *lastName = @"";
+        NSRange spaceRange = [displayName rangeOfString:@" "];
+        if (spaceRange.location != NSNotFound) {
+            firstName = [displayName substringToIndex:spaceRange.location];
+            lastName = [[displayName substringFromIndex:(spaceRange.location + 1)] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+
+        // Resolve avatar image data + on-disk path. IMNicknameAvatarImage prefers a path Apple controls.
+        NSData *imageData = nil;
+        NSString *resolvedAvatarPath = nil;
+        if (avatarPath != nil && (id)avatarPath != [NSNull null] && [avatarPath length] > 0) {
+            imageData = [NSData dataWithContentsOfFile:avatarPath];
+            resolvedAvatarPath = avatarPath;
+        } else if (avatarBytes != nil && (id)avatarBytes != [NSNull null] && [avatarBytes length] > 0) {
+            imageData = [[NSData alloc] initWithBase64EncodedString:avatarBytes options:NSDataBase64DecodingIgnoreUnknownCharacters];
+        }
+
+        IMNicknameAvatarImage *avatar = nil;
+        if (imageData != nil) {
+            // Copy bytes into the path Apple expects so the avatar persists across syncs.
+            NSString *destPath = [IMNickname uniqueFilePathForWritingImageData];
+            NSError *writeError = nil;
+            avatar = [[IMNicknameAvatarImage alloc] initWithImageName:displayName imageData:imageData imageFilePath:(destPath ?: resolvedAvatarPath) error:&writeError];
+            if (avatar == nil && resolvedAvatarPath != nil) {
+                avatar = [[IMNicknameAvatarImage alloc] initWithImageName:displayName imageFilePath:resolvedAvatarPath];
+            }
+        }
+
+        IMNickname *nickname = [[IMNickname alloc] initWithFirstName:firstName lastName:lastName avatar:avatar];
+        [nickname setDisplayName:displayName];
+
+        IMNicknameController *controller = [IMNicknameController sharedInstance];
+        [controller updatePersonalNickname:nickname];
+        // Persist locally so Messages.app picks it up on next launch as well as immediately.
+        if ([controller respondsToSelector:@selector(_updateLocalNicknameStore)]) {
+            [controller _updateLocalNicknameStore];
+        }
+
+        if (transaction != nil) {
+            [[NetworkController sharedInstance] sendMessage: @{
+                @"transactionId": transaction,
+                @"name": displayName,
+                @"avatar_path": resolvedAvatarPath ?: [NSNull null],
+            }];
+        }
     // If the server tells us to get the current account info
     } else if ([event isEqualToString:@"get-account-info"]) {
         IMAccountController *controller = [IMAccountController sharedInstance];


### PR DESCRIPTION
## Summary
- Adds a new helper action, `set-nickname-info`, that writes the user's iMessage Share Name and Photo (nickname + avatar) on behalf of a connected client.
- Mirrors the dispatch / import shape of the existing `get-nickname-info` and `share-nickname` handlers so the read and write paths share the same `IMNicknameController` plumbing.
- Builds an `IMNickname` via `initWithFirstName:lastName:avatar:` (splitting on the first space), wraps the avatar in `IMNicknameAvatarImage initWithImageName:imageData:imageFilePath:error:`, and commits with `[IMNicknameController sharedInstance] updatePersonalNickname:`. Calls `_updateLocalNicknameStore` after to persist locally.

## Action shape
Incoming params on the existing TCP socket:
- `displayName` (string, required)
- `avatarPath` (string, optional - filesystem path the BB server has already written)
- `avatarBytes` (string, optional - base64 image bytes; used if no path given)

Response: `{ transactionId, name, avatar_path }` on success, or `{ transactionId, error }` on validation failure - matches the get/read counterpart.

## Build / install (next step, not done in this PR)
This change is source-only. The dylib has not been recompiled. To ship:

```sh
cd Messages/MacOS-11+/BlueBubblesHelper
pod install
xcodebuild -workspace BlueBubblesHelper.xcworkspace \
           -scheme BlueBubblesHelper \
           -configuration Release \
           -derivedDataPath build
# then replace the running dylib:
sudo cp build/Build/Products/Release/BlueBubblesHelper.dylib \
        /Applications/BlueBubbles.app/Contents/Resources/appResources/private-api/macos11/BlueBubblesHelper.dylib
```
Restart Messages.app (the BB server will re-inject) after replacement.

## Test plan
- [ ] Build dylib with Xcode against the macOS SDK on a target Mac.
- [ ] Replace `/Applications/BlueBubbles.app/Contents/Resources/appResources/private-api/macos11/BlueBubblesHelper.dylib`.
- [ ] Send `{action: "set-nickname-info", data: {displayName: "Test User", avatarPath: "/tmp/test.png"}}` from the BB server.
- [ ] Confirm Messages.app -> Settings -> Share Name and Photo reflects the new name + image.
- [ ] Round-trip with `get-nickname-info` to confirm persistence after Messages.app restart.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code.